### PR TITLE
Release 2.0.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ export const offset = (pageNum, limit, zeroIndex = true) =>
 export const page = (pageNum, zeroIndex = false) =>
   zeroIndex ? pageNum - 1 : pageNum;
 
-export const totalPages = (total, limit) =>
-  (total - (total % limit)) / limit + (total % limit > 0 ? 1 : 0);
+export const totalPages = (total, limit) => Math.ceil(total / limit);
 
 const unpaginatedConcurrent = (fn, limit, total, startPage = 1) => {
   const pages = range(startPage, totalPages(total, limit) + 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpaginated",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Depaginates paginated operations",
   "homepage": "https://github.com/manuscriptmastr/colanderjs",
   "keywords": [


### PR DESCRIPTION
- Simplify `totalPages()` logic with `Math.ceil()`