### PR TITLE
Release/2.0.4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Joshua Martin
+Copyright (c) 2020 Joshua Martin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following utilities are included to help `unpaginated()` speak the language 
   - `page(pageNum, zeroIndex = false)`
 
 ```js
-import unpaginated, { offset } = from 'unpaginated';
+import unpaginated, { offset } from 'unpaginated';
 import fetch from 'node-fetch';
 
 const url = 'http://api.example';
@@ -53,3 +53,9 @@ const fetchUsers = (offset = 0, limit = 100) =>
 
 unpaginated((page, limit) => fetchUsers(offset(page, limit), limit), 200);
 ```
+
+## ES Modules
+As of version `2.0.4`, `unpaginated` is 100% ES Module friendly but backwards compatible. You can use `unpaginated` in a project:
+- with `"type": "module"` set in your top-level `package.json`
+- with a bundler like Webpack (e.g. `create-react-app`)
+- with only CommonJS support

--- a/README.md
+++ b/README.md
@@ -58,4 +58,7 @@ unpaginated((page, limit) => fetchUsers(offset(page, limit), limit), 200);
 As of version `2.0.4`, `unpaginated` is 100% ES Module friendly but backwards compatible. You can use `unpaginated` in a project:
 - with `"type": "module"` set in your top-level `package.json`
 - with a bundler like Webpack (e.g. `create-react-app`)
-- with only CommonJS support
+- with only CommonJS support:
+```js
+const { default: unpaginated, offset, page, totalPages } = require('unpaginated');
+```

--- a/dist.js
+++ b/dist.js
@@ -1,0 +1,2 @@
+require = require("esm")(module);
+module.exports = require("./index.js");

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
-import R from 'ramda';
-const { andThen, both, has, is, pipeWith, prop, range, unnest } = R;
+import andThen from 'ramda/src/andThen.js';
+import both from 'ramda/src/both.js';
+import has from 'ramda/src/has.js';
+import is from 'ramda/src/is.js';
+import pipeWith from 'ramda/src/pipeWith.js';
+import prop from 'ramda/src/prop.js';
+import range from 'ramda/src/range.js';
+import unnest from 'ramda/src/unnest.js';
 
 export const offset = (pageNum, limit, zeroIndex = true) =>
   (pageNum - 1) * limit + (zeroIndex ? 0 : 1);

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,9 @@
 import test from 'ava';
-import R from 'ramda';
+import andThen from 'ramda/src/andThen.js';
+import pipe from 'ramda/src/pipe.js';
+import range from 'ramda/src/range.js';
+import tap from 'ramda/src/tap.js';
 import unpaginated, { offset, page, totalPages } from './index.js';
-const { andThen, pipe, range, tap } = R;
 
 const POSTS = range(1, 101).map(num => ({ id: num }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unpaginated",
-  "version": "1.1.0",
+  "version": "2.0.4-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,15 +170,27 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
+      "version": "13.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
       "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
       "dev": true
     },
     "aggregate-error": {
@@ -306,21 +318,23 @@
       "dev": true
     },
     "ava": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-3.7.0.tgz",
-      "integrity": "sha512-SV1oqRpZ00qevETsNzcqTqaTnspJZZ1wBGOjyQzcLOMChnUF+17/RS4YiieClaV0eCFULLU/roICpJoQlNLHZw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-3.8.1.tgz",
+      "integrity": "sha512-OPWrTxcf1EbtAaGGFQPLbx4AaVqPrFMumKOKn2SzIRo+RTKb33lF2aoVnWqBeZaJ68uSc9R6jqIE7qkG6O33uQ==",
       "dev": true,
       "requires": {
         "@concordance/react": "^2.0.0",
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1",
         "ansi-styles": "^4.2.1",
         "arrgv": "^1.0.2",
         "arrify": "^2.0.1",
+        "callsites": "^3.1.0",
         "chalk": "^4.0.0",
-        "chokidar": "^3.3.1",
+        "chokidar": "^3.4.0",
         "chunkd": "^2.0.1",
         "ci-info": "^2.0.0",
         "ci-parallel-vars": "^1.0.0",
-        "clean-stack": "^2.2.0",
         "clean-yaml-object": "^0.1.0",
         "cli-cursor": "^3.1.0",
         "cli-truncate": "^2.1.0",
@@ -340,13 +354,13 @@
         "indent-string": "^4.0.0",
         "is-error": "^2.2.2",
         "is-plain-object": "^3.0.0",
-        "is-promise": "^2.1.0",
+        "is-promise": "^3.0.0",
         "lodash": "^4.17.15",
-        "matcher": "^2.1.0",
+        "matcher": "^3.0.0",
         "md5-hex": "^3.0.1",
         "mem": "^6.1.0",
         "ms": "^2.1.2",
-        "ora": "^4.0.3",
+        "ora": "^4.0.4",
         "p-map": "^4.0.0",
         "picomatch": "^2.2.2",
         "pkg-conf": "^3.1.0",
@@ -355,7 +369,7 @@
         "read-pkg": "^5.2.0",
         "resolve-cwd": "^3.0.0",
         "slash": "^3.0.0",
-        "source-map-support": "^0.5.16",
+        "source-map-support": "^0.5.19",
         "stack-utils": "^2.0.1",
         "strip-ansi": "^6.0.0",
         "supertap": "^1.0.0",
@@ -475,6 +489,12 @@
         }
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -492,9 +512,9 @@
       }
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -504,7 +524,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.4.0"
       }
     },
     "chunkd": {
@@ -873,6 +893,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -949,9 +974,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -1036,9 +1061,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "has-flag": {
@@ -1240,9 +1265,9 @@
       }
     },
     "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-3.0.0.tgz",
+      "integrity": "sha512-aTHJ4BvETyySzLhguH+7sL4b8765eecqq7ZrHVuhZr3FjCL/IV+LsvisEeH+9d0AkChYny3ad1KEL+mKy4ot7A==",
       "dev": true
     },
     "is-typedarray": {
@@ -1441,9 +1466,9 @@
       "dev": true
     },
     "make-dir": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -1467,18 +1492,18 @@
       }
     },
     "matcher": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
-      "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^2.0.0"
+        "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         }
       }
@@ -1614,9 +1639,9 @@
       }
     },
     "ora": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
-      "integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
+      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
@@ -1906,12 +1931,12 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.2.1"
       }
     },
     "registry-auth-token": {
@@ -1945,9 +1970,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2079,9 +2104,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -2099,9 +2124,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -2127,9 +2152,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-BvBTnHGm8boe+HiJFqP19ywEsGlfQAKqW78pbfvUuzCbUuxPPUyLrH5dYFY+Xn9IpLY3b5ZmMcl8jAqXB4wddg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+      "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -2432,9 +2457,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "unpaginated",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "Depaginates paginated operations",
-  "homepage": "https://github.com/manuscriptmastr/colanderjs",
+  "homepage": "https://github.com/manuscriptmastr/unpaginated#readme",
+  "bugs": {
+    "url": "https://github.com/manuscriptmastr/unpaginated/issues"
+  },
   "keywords": [
     "pagination",
     "depaginate",
@@ -12,20 +15,24 @@
     "page",
     "offset"
   ],
-  "main": "index.js",
+  "type": "module",
+  "main": "./dist.js",
+  "module": "./index.js",
+  "exports": {
+    "require": "./dist.js",
+    "import": "./index.js",
+    "default": "./index.js"
+  },
   "scripts": {
     "test": "ava --verbose --watch"
   },
   "author": "Joshua Martin",
   "license": "ISC",
   "dependencies": {
+    "esm": "^3.2.25",
     "ramda": "^0.27.0"
   },
-  "type": "module",
   "devDependencies": {
-    "ava": "^3.7.0"
-  },
-  "engines" : {
-    "node" : ">=13.2.0"
+    "ava": "^3.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpaginated",
-  "version": "2.0.4-beta.1",
+  "version": "2.0.4",
   "description": "Depaginates paginated operations",
   "homepage": "https://github.com/manuscriptmastr/unpaginated#readme",
   "bugs": {


### PR DESCRIPTION
# ES Modules
As of version `2.0.4`, `unpaginated` is 100% ES Module friendly but backwards compatible. You can use `unpaginated` in a project:
- with `"type": "module"` set in your top-level `package.json`
- with a bundler like Webpack (e.g. `create-react-app`)
- with only CommonJS support:
```js
const { default: unpaginated, offset, page, totalPages } = require('unpaginated');
```