### PR TITLE
Simplify interface to only require function; add cursor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,38 @@
 # unpaginated
 
-No one likes paginated results. `unpaginated()` executes a paginated function until done.
+Dead simple pagination. `unpaginated()` executes a paginated function until done, gathering results as efficiently as possible.
 
 ```js
 import unpaginated  from 'unpaginated';
 import fetch from 'node-fetch';
 
+// Say our API has 100 posts available
 const url = 'http://api.example';
 
-const fetchPosts = (page = 1, limit = 100) =>
-  fetch(`${url}/posts?_page=${page}&_limit=${limit}`)
+// Simplest case: return an array of results
+const fetchPosts = (page = 1) =>
+  fetch(`${url}/posts?_page=${page}&_limit=20`)
     .then(res => res.json())
     .then(payload => payload.data);
 
-const fetchPostsTotal = () => fetch(`${url}/posts/total`);
-
+// makes 6 requests, serially. Sixth request was empty
 unpaginated(fetchPosts);
-// makes 2 requests, serially. 1st returned 100 results, 2nd returned 0
 
-unpaginated(fetchPosts, 20);
-// makes 6 requests, serially. First 5 returned 20 results, 6th returned 0
+// Better case: return an object with a cursor property
+const fetchPostsWithCursor = (cursor = '') =>
+  fetch(`${url}/posts?_cursor=${cursor}&_limit=20`)
+    .then(res => res.json())
+    .then(({ data, cursor }) => ({ data, cursor }));
 
-unpaginated(fetchPosts, 20, fetchPostsTotal);
-// makes 1 serial request to get total, then makes 5 concurrent requests
+// makes 5 requests, serially.
+unpaginated(fetchPostsWithCursor);
 
-unpaginated(fetchPosts, 20, 100);
-// makes 5 requests, concurrently.
-
-// You can also return a payload object with data and total properties set.
-const fetchPostsWithTotal = (page = 1, limit = 100) =>
-  fetch(`${url}/posts?_page=${page}&_limit=${limit}`)
+// Best case: return an object with a total property
+const fetchPostsWithTotal = (page = 1) =>
+  fetch(`${url}/posts?_page=${page}&_limit=20`)
     .then(res => res.json())
     .then(({ data, total }) => ({ data, total }));
 
-unpaginated(fetchPostsWithTotal, 20);
 // makes 1 request serially, then 4 concurrently
-```
-
-The following utilities are included to help `unpaginated()` speak the language of your API:
-  - `offset(pageNum, limit, zeroIndex = true)`
-  - `page(pageNum, zeroIndex = false)`
-
-```js
-import unpaginated, { offset } from 'unpaginated';
-import fetch from 'node-fetch';
-
-const url = 'http://api.example';
-
-const fetchUsers = (offset = 0, limit = 100) =>
-  fetch(`${url}/users?offset=${offset}&limit=${limit}`)
-    .then(res => res.json());
-
-unpaginated((page, limit) => fetchUsers(offset(page, limit), limit), 200);
-```
-
-## ES Modules
-As of version `2.0.4`, `unpaginated` is 100% ES Module friendly but backwards compatible. You can use `unpaginated` in a project:
-- with `"type": "module"` set in your top-level `package.json`
-- with a bundler like Webpack (e.g. `create-react-app`)
-- with only CommonJS support:
-```js
-const { default: unpaginated, offset, page, totalPages } = require('unpaginated');
+unpaginated(fetchPostsWithTotal);
 ```

--- a/dist.js
+++ b/dist.js
@@ -1,2 +1,2 @@
 require = require("esm")(module);
-module.exports = require("./index.js");
+module.exports = require("./index.js").default;

--- a/index.js
+++ b/index.js
@@ -1,83 +1,75 @@
-import andThen from 'ramda/src/andThen.js';
 import both from 'ramda/src/both.js';
+import curry from 'ramda/src/curry.js';
 import has from 'ramda/src/has.js';
-import is from 'ramda/src/is.js';
-import pipeWith from 'ramda/src/pipeWith.js';
-import prop from 'ramda/src/prop.js';
-import range from 'ramda/src/range.js';
-import unnest from 'ramda/src/unnest.js';
+import partialRight from 'ramda/src/partialRight.js';
 
-export const offset = (pageNum, limit, zeroIndex = true) =>
-  (pageNum - 1) * limit + (zeroIndex ? 0 : 1);
+const chainRec = curry(async (fn, acc) => {
+  const next = value => ({ tag: next, value });
+  const done = value => ({ tag: done, value });
+  const { value, tag } = await fn(next, done, acc);
+  return tag === next ? chainRec(fn, value) : value;
+});
 
-export const page = (pageNum, zeroIndex = false) =>
-  zeroIndex ? pageNum - 1 : pageNum;
+const _serial = curry((fn, acc) => chainRec(
+  (next, done, { data, page, limit }) => fn(page).then(d =>
+    limit === undefined
+      ?  next({ data: data.concat(d), page: page + 1, limit: d.length })
+      :  d.length === limit
+          ? next({ data: data.concat(d), page: page + 1, limit })
+          : done(data.concat(d))
+  ),
+  acc
+));
 
-export const totalPages = (total, limit) => Math.ceil(total / limit);
+const _concurrent = curry((fn, acc) => chainRec(
+  (next, done, { data, page, limit, total }) =>
+    total === undefined
+      ? fn(page).then(({ data: d, total }) =>
+          d.length < total
+            ? next({ data: [Promise.resolve(data.concat(d))], page: page + 1, limit: d.length, total })
+            : done(d)
+        )
+      : page * limit < total
+        ? next({ data: [...data, fn(page).then(res => res.data)], page: page + 1, limit, total })
+        : done(Promise.all([...data, fn(page).then(res => res.data)]).then(arr => arr.flat()))
+  ,
+  acc
+));
 
-const unpaginatedConcurrent = (fn, limit, total, startPage = 1) => {
-  const pages = range(startPage, totalPages(total, limit) + 1);
-  return Promise.all(pages.map(page => fn(page, limit))).then(unnest);
-};
+const _cursor = curry((fn, acc) => chainRec(
+  (next, done, { data, cursor }) => fn(cursor).then(({ data: d, cursor: c }) =>
+    d.length > 0 && (typeof c === 'string' || typeof c === 'number')
+      ? next({ data: data.concat(d), cursor: c })
+      : done(data.concat(d))
+  ),
+  acc
+));
 
-export const unpaginatedSerial = async (fn, limit, startPage = 1) => {
-  let entries = [];
-  let done = false;
-  let page = startPage;
+export const serial = partialRight(_serial, [{ data: [], page: 1 }]);
+export const concurrent = partialRight(_concurrent, [{ data: [], page: 1 }]);
+export const cursor = partialRight(_cursor, [{ data: [] }]);
 
-  while (!done) {
-    const newEntries = await fn(page, limit);
-    entries = entries.concat(newEntries);
-    done = newEntries.length < limit;
-    page += 1;
-  };
-
-  return entries;
-};
+const raise = err => { throw err };
+const p = fn => async (...args) => fn(...args);
 
 /**
- * Executes a paginated function over all pages, preferring concurrency where possible.
- * @async
- * @template T
- * @param {(page: number, limit: number) => Promise<T[] | { data: T[], total: number }>} fn
- * @param {number} limit
- * @param {(number | (() => number) | (() => Promise<number>))} [total]
- * @returns {Promise<T[]>} An array of all entries
- * @example
- * const fetchUsers = (page, limit) => fetch(`/users?page=${page}&limit=${limit}`).then(res => res.json());
- * await unpaginated(fetchUsers, 20, 100);
- *   // => Array of all 100 users
- */
-const unpaginated = async (fn, limit = 100, total) => {
-  if (total !== undefined) {
-    const _total = is(Function, total) ?
-        await total()
-    : is(Number, total) ?
-        total
-    : raise(new TypeError('total argument must be a number or a sync/async function that returns a number'));
-    return unpaginatedConcurrent(fn, limit, _total, 1);
-  }
-
-  const firstEntries = await fn(1, limit);
-  const isDataObject = both(has('data'), has('total'));
-
-  if (isDataObject(firstEntries)) {
-    const { data, total } = firstEntries;
-    if (data.length >= total) {
-      return data;
-    } else {
-      const funcDataOnly = pipeWith(andThen, [fn, prop('data')]);
-      const leftOverEntries = await unpaginatedConcurrent(funcDataOnly, limit, total, 2);
-      return [...data, ...leftOverEntries];
-    }
-  } else {
-    if (firstEntries.length < limit) {
-      return firstEntries;
-    } else {
-      const leftOverEntries = await unpaginatedSerial(fn, limit, 2);
-      return [...firstEntries, ...leftOverEntries];
-    }
-  }
-};
-
-export default unpaginated;
+* Executes a paginated function over all pages, preferring concurrency where possible.
+* @async
+* @template T
+* @param {(page: number) => Promise<T[] | { data: T[], cursor: (string | number) } | { data: T[], total: number }>} fn
+* @returns {Promise<T[]>} An array of all entries
+* @example
+* const fetchUsers = (page = 1) => fetch(`/users?page=${page}&limit=100`).then(res => res.json());
+* await unpaginated(fetchUsers);
+*   // => Array of all users
+*/
+export default fn => p(fn)().then(d =>
+  Array.isArray(d) ?
+    d.length ? _serial(p(fn), { data: d, page: 2 }) : d
+: both(has('data'), has('total'))(d) ?
+    d.data.length ? _concurrent(p(fn), { ...d, page: 2, limit: d.data.length }) : d.data
+: both(has('data'), has('cursor'))(d) ?
+    d.data.length ? _cursor(p(fn), d) : d.data
+:
+    raise(new TypeError('Function must return an array or an object with an array'))
+);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const _serial = curry((fn, acc) => chainRec(
   (next, done, { data, page, limit }) => fn(page).then(d =>
     limit === undefined
       ?  next({ data: data.concat(d), page: page + 1, limit: d.length })
-      :  d.length === limit
+      :  d.length === limit && d.length !== 0
           ? next({ data: data.concat(d), page: page + 1, limit })
           : done(data.concat(d))
   ),

--- a/index.js
+++ b/index.js
@@ -11,12 +11,10 @@ const chainRec = curry(async (fn, acc) => {
 });
 
 const _serial = curry((fn, acc) => chainRec(
-  (next, done, { data, page, limit }) => fn(page).then(d =>
-    limit === undefined
-      ?  next({ data: data.concat(d), page: page + 1, limit: d.length })
-      :  d.length === limit && d.length !== 0
-          ? next({ data: data.concat(d), page: page + 1, limit })
-          : done(data.concat(d))
+  (next, done, { data, page, prev }) => fn(page).then(d =>
+    prev === undefined || (d.length === prev && d.length !== 0)
+      ? next({ data: data.concat(d), page: page + 1, prev: d.length })
+      : done(data.concat(d))
   ),
   acc
 ));

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const _concurrent = curry((fn, acc) => chainRec(
 
 const _cursor = curry((fn, acc) => chainRec(
   (next, done, { data, cursor }) => fn(cursor).then(({ data: d, cursor: c }) =>
-    d.length > 0 && (typeof c === 'string' || typeof c === 'number')
+    d.length > 0 && ((typeof c === 'string' && c.length > 0) || typeof c === 'number')
       ? next({ data: data.concat(d), cursor: c })
       : done(data.concat(d))
   ),

--- a/index.js
+++ b/index.js
@@ -1,25 +1,20 @@
-import both from 'ramda/src/both.js';
-import curry from 'ramda/src/curry.js';
-import has from 'ramda/src/has.js';
-import partialRight from 'ramda/src/partialRight.js';
-
-const chainRec = curry(async (fn, acc) => {
+const chainRec = async (fn, acc) => {
   const next = value => ({ tag: next, value });
   const done = value => ({ tag: done, value });
   const { value, tag } = await fn(next, done, acc);
   return tag === next ? chainRec(fn, value) : value;
-});
+};
 
-const _serial = curry((fn, acc) => chainRec(
+const _serial = (fn, acc) => chainRec(
   (next, done, { data, page, limit = 0 }) => fn(page).then(d =>
     d.length === 0 || d.length < limit
       ? done(data.concat(d))
       : next({ data: data.concat(d), page: page + 1, limit: d.length })
   ),
   acc
-));
+);
 
-const _concurrent = curry((fn, acc) => chainRec(
+const _concurrent = (fn, acc) => chainRec(
   (next, done, { data, page, limit, total }) =>
     total === undefined
       ? fn(page).then(({ data: d, total: t }) =>
@@ -32,25 +27,28 @@ const _concurrent = curry((fn, acc) => chainRec(
         : done(Promise.all([...data, fn(page).then(res => res.data)]).then(arr => arr.flat()))
   ,
   acc
-));
+);
 
 const isValidCursor = cursor => ((typeof cursor === 'string' && cursor.length > 0) || typeof cursor === 'number');
 
-const _cursor = curry((fn, acc) => chainRec(
+const _cursor = (fn, acc) => chainRec(
   (next, done, { data, cursor }) => fn(cursor).then(({ data: d, cursor: c }) =>
     d.length > 0 && isValidCursor(c)
       ? next({ data: data.concat(d), cursor: c })
       : done(data.concat(d))
   ),
   acc
-));
+);
 
-export const serial = partialRight(_serial, [{ data: [], page: 1 }]);
-export const concurrent = partialRight(_concurrent, [{ data: [], page: 1 }]);
-export const cursor = partialRight(_cursor, [{ data: [] }]);
+export const serial = fn => _serial(fn, { data: [], page: 1 });
+export const concurrent = fn => _concurrent(fn, { data: [], page: 1 });
+export const cursor = fn => _cursor(fn, { data: [] });
 
 const raise = err => { throw err };
 const p = fn => async (...args) => fn(...args);
+
+const isConcurrentObject = obj => typeof obj === 'object' && obj.hasOwnProperty('data') && obj.hasOwnProperty('total');
+const isCursorObject = obj => typeof obj === 'object' && obj.hasOwnProperty('data') && obj.hasOwnProperty('cursor');;
 
 /**
 * Executes a paginated function over all pages, preferring concurrency where possible.
@@ -66,9 +64,9 @@ const p = fn => async (...args) => fn(...args);
 export default fn => p(fn)().then(d =>
   Array.isArray(d) ?
     d.length ? _serial(p(fn), { data: d, page: 2 }) : d
-: both(has('data'), has('total'))(d) ?
+: isConcurrentObject(d) ?
     d.data.length ? _concurrent(p(fn), { ...d, page: 2, limit: d.data.length }) : d.data
-: both(has('data'), has('cursor'))(d) ?
+: isCursorObject(d) ?
     d.data.length && isValidCursor(d.cursor) ? _cursor(p(fn), d) : d.data
 :
     raise(new TypeError('Function must return an array or an object with an array'))

--- a/index.test.js
+++ b/index.test.js
@@ -4,18 +4,6 @@ import range from 'ramda/src/range.js';
 import tap from 'ramda/src/tap.js';
 import unpaginated, { concurrent, cursor, serial } from './index.js';
 
-/*
-TODO:
-2. Update README
-3. Make mocks more realistic
-4. Consider alternative interfaces. Does this feel natural for:
-  - fn that returns array?
-  - fn that returns { data, total }?
-  - fn that returns { data, cursor }?
-  - fn that requires an offset?
-  - APIs where a separate call must be made for total?
-*/
-
 const POSTS = range(1, 101).map(num => ({ id: num }));
 
 const offset = (pageNum, limit, zeroIndex = true) =>
@@ -24,19 +12,14 @@ const offset = (pageNum, limit, zeroIndex = true) =>
 const FETCH_POSTS = async (limit, page = 1) =>
   POSTS.slice(offset(page, limit), offset(page + 1, limit));
 
-const POSTS_OBJECT = {
-  0: { data: POSTS.slice(0, 20), cursor: 1 },
-  1: { data: POSTS.slice(20, 40), cursor: 2 },
-  2: { data: POSTS.slice(40, 60), cursor: 3 },
-  3: { data: POSTS.slice(60, 80), cursor: 4 },
-  4: { data: POSTS.slice(80, 100), cursor: null }
-};
-
-const FETCH_POSTS_WITH_CURSOR = async (cursor = 0) => POSTS_OBJECT[cursor];
-
 const FETCH_POSTS_WITH_TOTAL = async (limit, page = 1) => ({
   data: POSTS.slice(offset(page, limit), offset(page + 1, limit)),
   total: POSTS.length
+});
+
+const FETCH_POSTS_WITH_CURSOR = async (limit, cursor = 0) => ({
+  data: POSTS.slice(cursor, cursor + limit),
+  cursor: cursor + limit >= POSTS.length ? null : cursor + limit
 });
 
 test('concurrent(fn), empty case', async t => {
@@ -109,9 +92,16 @@ test('cursor(fn), single case', async t => {
   t.deepEqual(times, 1);
 });
 
+test('cursor(fn), exact case', async t => {
+  let times = 0;
+  const fetchPosts = pipe(cur => FETCH_POSTS_WITH_CURSOR(20, cur), tap(() => { times += 1 }));
+  t.deepEqual(await unpaginated(fetchPosts), POSTS);
+  t.deepEqual(times, 5);
+});
+
 test('cursor(fn), leftover case', async t => {
   let times = 0;
-  const fetchPosts = pipe(FETCH_POSTS_WITH_CURSOR, tap(() => { times += 1 }));
+  const fetchPosts = pipe(cur => FETCH_POSTS_WITH_CURSOR(21, cur), tap(() => { times += 1 }));
   t.deepEqual(await unpaginated(fetchPosts), POSTS);
   t.deepEqual(times, 5);
 });
@@ -130,9 +120,16 @@ test('unpaginated(fn), single case, cursor', async t => {
   t.deepEqual(times, 1);
 });
 
+test('unpaginated(fn), exact case, cursor', async t => {
+  let times = 0;
+  const fetchPosts = pipe(cur => FETCH_POSTS_WITH_CURSOR(20, cur), tap(() => { times += 1 }));
+  t.deepEqual(await unpaginated(fetchPosts), POSTS);
+  t.deepEqual(times, 5);
+});
+
 test('unpaginated(fn), leftover case, cursor', async t => {
   let times = 0;
-  const fetchPosts = pipe(FETCH_POSTS_WITH_CURSOR, tap(() => { times += 1 }));
+  const fetchPosts = pipe(cur => FETCH_POSTS_WITH_CURSOR(21, cur), tap(() => { times += 1 }));
   t.deepEqual(await unpaginated(fetchPosts), POSTS);
   t.deepEqual(times, 5);
 });

--- a/index.test.js
+++ b/index.test.js
@@ -6,10 +6,6 @@ import unpaginated, { concurrent, cursor, serial } from './index.js';
 
 /*
 TODO:
-1. Align test cases for all strategies
-  - Empty case
-  - Odd number case
-  - Incorrect input case
 2. Update README
 3. Make mocks more realistic
 4. Consider alternative interfaces. Does this feel natural for:
@@ -50,6 +46,13 @@ test('concurrent(fn), empty case', async t => {
   t.deepEqual(times, 1);
 });
 
+test('concurrent(fn), single case', async t => {
+  let times = 0;
+  const fetchPosts = pipe(async () => ({ data: [], total: 100 }), tap(() => { times += 1 }));
+  t.deepEqual(await concurrent(fetchPosts), []);
+  t.deepEqual(times, 1);
+});
+
 test('concurrent(fn), exact case', async t => {
   let times = 0;
   const fetchPosts = pipe(pg => FETCH_POSTS_WITH_TOTAL(20, pg), tap(() => { times += 1 }));
@@ -67,6 +70,13 @@ test('concurrent(fn), leftover case', async t => {
 test('unpaginated(fn), empty case, concurrent', async t => {
   let times = 0;
   const fetchPosts = pipe(async () => ({ data: [], total: 0 }), tap(() => { times += 1 }));
+  t.deepEqual(await unpaginated(fetchPosts), []);
+  t.deepEqual(times, 1);
+});
+
+test('unpaginated(fn), single case, concurrent', async t => {
+  let times = 0;
+  const fetchPosts = pipe(async () => ({ data: [], total: 100 }), tap(() => { times += 1 }));
   t.deepEqual(await unpaginated(fetchPosts), []);
   t.deepEqual(times, 1);
 });
@@ -99,7 +109,7 @@ test('cursor(fn), single case', async t => {
   t.deepEqual(times, 1);
 });
 
-test('curosr(fn), leftover case', async t => {
+test('cursor(fn), leftover case', async t => {
   let times = 0;
   const fetchPosts = pipe(FETCH_POSTS_WITH_CURSOR, tap(() => { times += 1 }));
   t.deepEqual(await unpaginated(fetchPosts), POSTS);
@@ -134,6 +144,13 @@ test('serial(fn), empty case', async t => {
   t.deepEqual(times, 1);
 });
 
+test('serial(fn), single case', async t => {
+  let times = 0;
+  const fetchPosts = pipe(pg => FETCH_POSTS(100, pg), tap(() => { times += 1 }));
+  t.deepEqual(await serial(fetchPosts), POSTS);
+  t.deepEqual(times, 2);
+});
+
 test('serial(fn), exact case', async t => {
   let times = 0;
   const fetchPosts = pipe(pg => FETCH_POSTS(20, pg), tap(() => { times += 1 }));
@@ -146,6 +163,13 @@ test('serial(fn), leftover case', async t => {
   const fetchPosts = pipe(pg => FETCH_POSTS(21, pg), tap(() => { times += 1 }));
   t.deepEqual(await serial(fetchPosts), POSTS);
   t.deepEqual(times, 5);
+});
+
+test('unpaginated(fn), single case, serial', async t => {
+  let times = 0;
+  const fetchPosts = pipe(pg => FETCH_POSTS(100, pg), tap(() => { times += 1 }));
+  t.deepEqual(await unpaginated(fetchPosts), POSTS);
+  t.deepEqual(times, 2);
 });
 
 test('unpaginated(fn), empty case, serial', async t => {

--- a/index.test.js
+++ b/index.test.js
@@ -4,6 +4,22 @@ import range from 'ramda/src/range.js';
 import tap from 'ramda/src/tap.js';
 import unpaginated from './index.js';
 
+/*
+TODO:
+1. Align test cases for all strategies
+  - Empty case
+  - Odd number case
+  - Incorrect input case
+2. Update README
+3. Make mocks more realistic
+4. Consider alternative interfaces. Does this feel natural for:
+  - fn that returns array?
+  - fn that returns { data, total }?
+  - fn that returns { data, cursor }?
+  - fn that requires an offset?
+  - APIs where a separate call must be made for total?
+*/
+
 const POSTS = range(1, 101).map(num => ({ id: num }));
 
 const offset = (pageNum, limit, zeroIndex = true) =>

--- a/index.test.js
+++ b/index.test.js
@@ -162,18 +162,18 @@ test('serial(fn), leftover case', async t => {
   t.deepEqual(times, 5);
 });
 
-test('unpaginated(fn), single case, serial', async t => {
-  let times = 0;
-  const fetchPosts = pipe(pg => FETCH_POSTS(100, pg), tap(() => { times += 1 }));
-  t.deepEqual(await unpaginated(fetchPosts), POSTS);
-  t.deepEqual(times, 2);
-});
-
 test('unpaginated(fn), empty case, serial', async t => {
   let times = 0;
   const fetchPosts = pipe(() => Promise.resolve([]), tap(() => { times += 1 }));
   t.deepEqual(await unpaginated(fetchPosts), []);
   t.deepEqual(times, 1);
+});
+
+test('unpaginated(fn), single case, serial', async t => {
+  let times = 0;
+  const fetchPosts = pipe(pg => FETCH_POSTS(100, pg), tap(() => { times += 1 }));
+  t.deepEqual(await unpaginated(fetchPosts), POSTS);
+  t.deepEqual(times, 2);
 });
 
 test('unpaginated(fn), exact case, serial', async t => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,9 +163,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
+      "version": "14.0.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
+      "integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,31 @@
 {
   "name": "unpaginated",
-  "version": "2.0.4-beta.1",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -146,19 +146,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -170,9 +163,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+      "version": "14.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -182,15 +175,15 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-walk": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
     "aggregate-error": {
@@ -318,43 +311,43 @@
       "dev": true
     },
     "ava": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-3.8.1.tgz",
-      "integrity": "sha512-OPWrTxcf1EbtAaGGFQPLbx4AaVqPrFMumKOKn2SzIRo+RTKb33lF2aoVnWqBeZaJ68uSc9R6jqIE7qkG6O33uQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-3.10.1.tgz",
+      "integrity": "sha512-+w86ZHyFHIGCABi7NUrn/WJMyC+fDj0BSIlFNVS45WDKAD5vxbIiDWeclctxOOc2KDPfQD7tFOURSBz0FBLD0A==",
       "dev": true,
       "requires": {
         "@concordance/react": "^2.0.0",
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1",
+        "acorn": "^7.3.1",
+        "acorn-walk": "^7.2.0",
         "ansi-styles": "^4.2.1",
         "arrgv": "^1.0.2",
         "arrify": "^2.0.1",
         "callsites": "^3.1.0",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "chokidar": "^3.4.0",
         "chunkd": "^2.0.1",
         "ci-info": "^2.0.0",
-        "ci-parallel-vars": "^1.0.0",
+        "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-cursor": "^3.1.0",
         "cli-truncate": "^2.1.0",
-        "code-excerpt": "^2.1.1",
+        "code-excerpt": "^3.0.0",
         "common-path-prefix": "^3.0.0",
-        "concordance": "^4.0.0",
+        "concordance": "^5.0.0",
         "convert-source-map": "^1.7.0",
         "currently-unhandled": "^0.4.1",
         "debug": "^4.1.1",
         "del": "^5.1.0",
-        "emittery": "^0.6.0",
+        "emittery": "^0.7.0",
         "equal-length": "^1.0.0",
         "figures": "^3.2.0",
-        "globby": "^11.0.0",
-        "ignore-by-default": "^1.0.0",
+        "globby": "^11.0.1",
+        "ignore-by-default": "^2.0.0",
         "import-local": "^3.0.2",
         "indent-string": "^4.0.0",
         "is-error": "^2.2.2",
-        "is-plain-object": "^3.0.0",
-        "is-promise": "^3.0.0",
+        "is-plain-object": "^3.0.1",
+        "is-promise": "^4.0.0",
         "lodash": "^4.17.15",
         "matcher": "^3.0.0",
         "md5-hex": "^3.0.1",
@@ -365,19 +358,19 @@
         "picomatch": "^2.2.2",
         "pkg-conf": "^3.1.0",
         "plur": "^4.0.0",
-        "pretty-ms": "^6.0.1",
+        "pretty-ms": "^7.0.0",
         "read-pkg": "^5.2.0",
         "resolve-cwd": "^3.0.0",
         "slash": "^3.0.0",
         "source-map-support": "^0.5.19",
-        "stack-utils": "^2.0.1",
+        "stack-utils": "^2.0.2",
         "strip-ansi": "^6.0.0",
         "supertap": "^1.0.0",
         "temp-dir": "^2.0.0",
         "trim-off-newlines": "^1.0.1",
         "update-notifier": "^4.1.0",
         "write-file-atomic": "^3.0.3",
-        "yargs": "^15.3.1"
+        "yargs": "^15.4.0"
       }
     },
     "balanced-match": {
@@ -387,15 +380,15 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "blueimp-md5": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.13.0.tgz",
-      "integrity": "sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.16.0.tgz",
+      "integrity": "sha512-j4nzWIqEFpLSbdhUApHRGDwfXbV8ALhqOn+FY5L6XBdKPAXU9BpGgFSbDsgqogfqPPR9R2WooseWCsfhfEC6uQ==",
       "dev": true
     },
     "boxen": {
@@ -502,9 +495,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -512,9 +505,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -540,9 +533,9 @@
       "dev": true
     },
     "ci-parallel-vars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
-      "integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
+      "integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
       "dev": true
     },
     "clean-stack": {
@@ -573,9 +566,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-      "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
       "dev": true
     },
     "cli-truncate": {
@@ -615,9 +608,9 @@
       }
     },
     "code-excerpt": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
-      "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
       "dev": true,
       "requires": {
         "convert-to-spaces": "^1.0.1"
@@ -651,33 +644,19 @@
       "dev": true
     },
     "concordance": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
-      "integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.0.tgz",
+      "integrity": "sha512-stOCz9ffg0+rytwTaL2njUOIyMfANwfwmqc9Dr4vTUS/x/KkVFlWx9Zlzu6tHYtjKxxaCF/cEAZgPDac+n35sg==",
       "dev": true,
       "requires": {
-        "date-time": "^2.1.0",
-        "esutils": "^2.0.2",
-        "fast-diff": "^1.1.2",
+        "date-time": "^3.1.0",
+        "esutils": "^2.0.3",
+        "fast-diff": "^1.2.0",
         "js-string-escape": "^1.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flattendeep": "^4.4.0",
-        "lodash.islength": "^4.0.1",
-        "lodash.merge": "^4.6.1",
-        "md5-hex": "^2.0.0",
-        "semver": "^5.5.1",
+        "lodash": "^4.17.15",
+        "md5-hex": "^3.0.1",
+        "semver": "^7.3.2",
         "well-known-symbols": "^2.0.0"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-          "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        }
       }
     },
     "configstore": {
@@ -725,9 +704,9 @@
       }
     },
     "date-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
       "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
@@ -846,9 +825,9 @@
       "dev": true
     },
     "emittery": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.6.0.tgz",
-      "integrity": "sha512-6EMRGr9KzYWp8DzHFZsKVZBsMO6QhAeHMeHND8rhyBNCHKMLpgW9tZv40bwN3rAIKRS5CxcK8oLRKUJSB9h7yQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+      "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -917,9 +896,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -931,9 +910,9 @@
       }
     },
     "fastq": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
-      "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1028,9 +1007,9 @@
       }
     },
     "globby": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -1091,15 +1070,15 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.0.0.tgz",
+      "integrity": "sha512-+mQSgMRiFD3L3AOxLYOCxjIq4OnAmo5CIuC+lj5ehCJcPtV++QacEV7FdpzvYxH6DaOySWzQU6RR0lPLy37ckA==",
       "dev": true
     },
     "import-lazy": {
@@ -1256,18 +1235,15 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-      "dev": true,
-      "requires": {
-        "isobject": "^4.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true
     },
     "is-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-3.0.0.tgz",
-      "integrity": "sha512-aTHJ4BvETyySzLhguH+7sL4b8765eecqq7ZrHVuhZr3FjCL/IV+LsvisEeH+9d0AkChYny3ad1KEL+mKy4ot7A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
     "is-typedarray": {
@@ -1280,12 +1256,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-      "dev": true
-    },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
     },
     "js-string-escape": {
@@ -1301,9 +1271,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1369,33 +1339,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
-    "lodash.islength": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
-      "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {
@@ -1517,12 +1463,6 @@
         "blueimp-md5": "^2.10.0"
       }
     },
-    "md5-o-matic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-      "dev": true
-    },
     "mem": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
@@ -1542,9 +1482,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -1606,6 +1546,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -1639,9 +1587,9 @@
       }
     },
     "ora": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.5.tgz",
+      "integrity": "sha512-jCDgm9DqvRcNIAEv2wZPrh7E5PcQiDUnbnWbAfu4NGAE2ZNqPFbDixmWldy1YG2QfLeQhuiu6/h5VRrk6cG50w==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
@@ -1854,9 +1802,9 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-6.0.1.tgz",
-      "integrity": "sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
+      "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
       "dev": true,
       "requires": {
         "parse-ms": "^2.1.0"
@@ -1940,9 +1888,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
+      "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
@@ -2040,9 +1988,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
     },
     "semver-diff": {
@@ -2114,9 +2062,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2130,9 +2078,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -2438,9 +2386,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "requires": {
         "cliui": "^6.0.0",
@@ -2453,7 +2401,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.1"
+        "yargs-parser": "^18.1.2"
       }
     },
     "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,7 +1832,8 @@
     "ramda": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
-      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA=="
+      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "ramda": "^0.27.0"
   },
   "devDependencies": {
-    "ava": "^3.8.1"
+    "ava": "^3.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "author": "Joshua Martin",
   "license": "ISC",
   "dependencies": {
-    "esm": "^3.2.25",
-    "ramda": "^0.27.0"
+    "esm": "^3.2.25"
   },
   "devDependencies": {
-    "ava": "^3.10.1"
+    "ava": "^3.10.1",
+    "ramda": "^0.27.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpaginated",
-  "version": "2.0.4",
+  "version": "3.0.0-beta.0",
   "description": "Depaginates paginated operations",
   "homepage": "https://github.com/manuscriptmastr/unpaginated#readme",
   "bugs": {
@@ -8,10 +8,12 @@
   },
   "keywords": [
     "pagination",
+    "paginate",
     "depaginate",
     "unpaginated",
     "functional",
     "concurrency",
+    "cursor",
     "page",
     "offset"
   ],


### PR DESCRIPTION
# TL;DR: one arg to rule them all
```js
import fetch from 'node-fetch';
import unpaginated from 'unpaginated';

const fetchUsers = (page = 1) => fetch(`/users/?page=${page}&limit=100`);
await unpaginated(fetchUsers);
// Returns array of all users
```

## Notes
- Removes all but the `fn` argument. I made this decision after using `unpaginated` on a dozen APIs and finding that optional `limit` and `total` arguments made for a confusing API and added verbosity to the paginated function, while optimizing for one edge case.
- Adds support for APIs supporting cursor-based pagination:
```js
import fetch from 'node-fetch';
import unpaginated from 'unpaginated';

const fetchSlackUsers = (cursor = '') =>
  fetch(`https://someworkspace.slack.com/api/users.list?limit=200&cursor=${cursor}`)
    .then(({ members, response_metadata }) => ({
      data: members,
      cursor: response_metadata.next_cursor
    }));
```
- Removes `page`, `offset`, and `totalPages` utilities. In practice, I found only `offset` was helpful, and that's as easy as:
```js
const offset = (pageNum, limit, zeroIndex = true) => (pageNum - 1) * limit + (zeroIndex ? 0 : 1);
```
- If you're writing in CommonJS, `unpaginated` is now the main export:
```js
const unpaginated = require('unpaginated');
```